### PR TITLE
Update to use cholesky factor for better stability on GPU

### DIFF
--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -12,7 +12,6 @@ class IaLogL:
     def __init__(self, df, cov, mb_column, z_cutoff=0.0):
 
         self.df = df
-        self.cov = cov
 
         mask = df['zHD'] > z_cutoff
         self.mb = array(df[mb_column].to_numpy()[mask])
@@ -20,7 +19,7 @@ class IaLogL:
         self.zhel = array(df['zHEL'].to_numpy()[mask])
 
         cov = cov[mask, :][:, mask]
-        self.cholesky_L, self.lognorm = self._compute_cholesky_and_lognorm( cov)
+        self.cholesky_L, self.lognorm = self._compute_cholesky_and_lognorm(cov)
 
     def _compute_cholesky_and_lognorm(self, cov):
         # Do all matrix operations in fp64 numpy for precision

--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -62,9 +62,7 @@ class IaLogL:
         # Use Cholesky decomposition to avoid GPU vmap bug
         # y.T @ M @ y = ||L.T @ y||² where M = L @ L.T
         v = self.cholesky_L.T @ y
-        quadratic_form = (v**2).sum()
-        result = -quadratic_form / 2.0 + self.lognormalisation
-        return result
+        return -(v**2).sum() / 2.0 + self.lognormalisation
 
 
 class IaLogLUnmarginalised(IaLogL):

--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -1,6 +1,5 @@
 import numpy as np
 from jax.numpy import array, log10
-import jax.numpy as jnp
 from scipy.constants import c
 
 
@@ -63,7 +62,7 @@ class IaLogL:
         # Use Cholesky decomposition to avoid GPU vmap bug
         # y.T @ M @ y = ||L.T @ y||² where M = L @ L.T
         v = self.cholesky_L.T @ y
-        quadratic_form = jnp.sum(v**2)
+        quadratic_form = (v**2).sum()
         result = -quadratic_form / 2.0 + self.lognormalisation
         return result
 

--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -19,8 +19,12 @@ class IaLogL:
         self.zhd = array(df['zHD'].to_numpy()[mask])
         self.zhel = array(df['zHEL'].to_numpy()[mask])
 
+        cov = cov[mask, :][:, mask]
+        self.cholesky_L, self.lognorm = self._compute_cholesky_and_lognorm( cov)
+
+    def _compute_cholesky_and_lognorm(self, cov):
         # Do all matrix operations in fp64 numpy for precision
-        cov_np = np.array(cov[mask, :][:, mask], dtype=np.float64)
+        cov_np = np.array(cov, dtype=np.float64)
         one_np = np.ones((len(cov_np), 1), dtype=np.float64)
 
         # Compute constrained inverse C^-1_tilde for marginalization
@@ -38,17 +42,18 @@ class IaLogL:
 
         # Compute Cholesky decomposition for GPU vmap bug fix
         # This avoids the problematic y.T @ M @ y operation
-        self.cholesky_L = array(np.linalg.cholesky(invcov_tilde / 2.0))
+        cholesky_L = array(np.linalg.cholesky(invcov_tilde / 2.0))
 
         # Compute log normalization in fp64
         sign, logdet = np.linalg.slogdet(cov_np)
         if sign != 1:
             raise ValueError("Covariance matrix must be positive definite.")
-        self.lognormalisation = -0.5 * (
+        lognorm = -0.5 * (
             logdet                           # log|C|
             + np.log(2*np.pi) * (len(cov_np) - 1)  # log(2π)^(n-1) after marginalization
             + np.log(one_T_invcov_one.item())       # log(1^T C^-1 1)
         )
+        return cholesky_L, lognorm
 
     def _y(self, params, cosmology):
         return 5 * log10(
@@ -61,34 +66,26 @@ class IaLogL:
         # Use Cholesky decomposition to avoid GPU vmap bug
         # y.T @ M @ y = ||L.T @ y||² where M = L @ L.T
         v = self.cholesky_L.T @ y
-        return -(v**2).sum() + self.lognormalisation
+        return -(v**2).sum() + self.lognorm
 
 
 class IaLogLUnmarginalised(IaLogL):
     requirements = {'h0_dl_over_c', 'h0', 'Mb'}
 
-    def __init__(self, df, cov, mb_column, z_cutoff=0.0):
+    def _compute_cholesky_and_lognorm(self, cov):
 
-        self.df = df
-        self.cov = cov
-
-        mask = df['zHD'] > z_cutoff
-        self.mb = array(df[mb_column].to_numpy()[mask])
-        self.zhd = array(df['zHD'].to_numpy()[mask])
-        self.zhel = array(df['zHEL'].to_numpy()[mask])
-
-        cov_np = np.array(cov[mask, :][:, mask])
-
-        self.cholesky_L = array(np.linalg.cholesky(
-            np.linalg.inv(cov_np) / 2.0
+        cholesky_L = array(np.linalg.cholesky(
+            np.linalg.inv(cov) / 2.0
         ))
 
         # Compute log normalization in fp64
-        sign, logdet = np.linalg.slogdet(cov_np)
-        self.lognormalisation = -0.5 * (
+        sign, logdet = np.linalg.slogdet(cov)
+        lognormalisation = -0.5 * (
             logdet
-            + np.log(2*np.pi) * len(cov_np)
+            + np.log(2*np.pi) * len(cov)
         )
+        return cholesky_L, lognormalisation
+
 
     def _y(self, params, cosmology):
         mu = 5 * log10(

--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -36,7 +36,7 @@ class IaLogL:
             - invcov_one @ np.linalg.solve(one_T_invcov_one, invcov_one.T)
         )
         self.invcov_tilde_over_2 = invcov_tilde / 2.0
-        
+
         # Compute Cholesky decomposition for GPU vmap bug fix
         # This avoids the problematic y.T @ M @ y operation
         self.cholesky_L = array(np.linalg.cholesky(invcov_tilde))

--- a/jayesian/likelihoods/ia.py
+++ b/jayesian/likelihoods/ia.py
@@ -35,11 +35,10 @@ class IaLogL:
             invcov_np
             - invcov_one @ np.linalg.solve(one_T_invcov_one, invcov_one.T)
         )
-        self.invcov_tilde_over_2 = invcov_tilde / 2.0
 
         # Compute Cholesky decomposition for GPU vmap bug fix
         # This avoids the problematic y.T @ M @ y operation
-        self.cholesky_L = array(np.linalg.cholesky(invcov_tilde))
+        self.cholesky_L = array(np.linalg.cholesky(invcov_tilde / 2.0))
 
         # Compute log normalization in fp64
         sign, logdet = np.linalg.slogdet(cov_np)
@@ -62,7 +61,7 @@ class IaLogL:
         # Use Cholesky decomposition to avoid GPU vmap bug
         # y.T @ M @ y = ||L.T @ y||² where M = L @ L.T
         v = self.cholesky_L.T @ y
-        return -(v**2).sum() / 2.0 + self.lognormalisation
+        return -(v**2).sum() + self.lognormalisation
 
 
 class IaLogLUnmarginalised(IaLogL):
@@ -81,7 +80,7 @@ class IaLogLUnmarginalised(IaLogL):
         cov_np = np.array(cov[mask, :][:, mask])
 
         self.cholesky_L = array(np.linalg.cholesky(
-            np.linalg.inv(cov_np)
+            np.linalg.inv(cov_np) / 2.0
         ))
 
         # Compute log normalization in fp64

--- a/monaco.py
+++ b/monaco.py
@@ -14,5 +14,5 @@ nsamples = 10000
 omegam = {"omegam": jax.numpy.array(np.random.rand(nsamples)*(0.98)+0.01)}
 print(omegam)
 
-logl = jax.vmap(lambda om: des5y(om, lcdm))(omegam)
+logl = jax.vmap(lambda om: pantheonplus(om, lcdm))(omegam)
 print(jax.scipy.special.logsumexp(logl) - np.log(nsamples))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "jayesian"
 dynamic = ["version"]
 description = "Dark Energy Jaxoscopic Instrument"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "anesthetic>=2.10.0",
     "blackjax",

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ for model in "${models[@]}"; do
     for likelihood in "${likelihoods[@]}"; do
         echo "$model $likelihood"
         uv run run.py "$model" $likelihood
+        echo ""
     done
 done
 
@@ -14,5 +15,6 @@ for i in {2..20}; do
     for likelihood in "${likelihoods[@]}"; do
         echo "flexknot $i $likelihood"
         uv run run.py "flexknot" $likelihood --n "$i"
+        echo ""
     done
 done

--- a/run.sh
+++ b/run.sh
@@ -6,13 +6,13 @@ likelihoods=("desidr2" "pantheonplus" "des5y" "desidr2 pantheonplus" "desidr2 de
 for model in "${models[@]}"; do
     for likelihood in "${likelihoods[@]}"; do
         echo "$model $likelihood"
-        uv run run.py "$model" "$likelihood"
+        uv run run.py "$model" $likelihood
     done
 done
 
 for i in {2..20}; do
     for likelihood in "${likelihoods[@]}"; do
         echo "flexknot $i $likelihood"
-        uv run run.py "flexknot" "$likelihood" --n "$i"
+        uv run run.py "flexknot" $likelihood --n "$i"
     done
 done


### PR DESCRIPTION
Introduces a minimal change to the current script that was hanging of using the cholesky decomposition to make the computation more numerically stable. Indeed there was some strange behaviour where a fp32 calc was giving different results on GPU and CPU

### TODO:

- [ ] Test this fix can be replicated
- [ ] Use cholesky for normalization as well as this should also be more stable
- [ ] Investigate using jnp for ops rather than needing fp64 numpy for cleanliness
- [ ] work through and make sure code is sensible we are inverting then calculating L which is likely redundant
- [ ] change other function to have same logic